### PR TITLE
Don't check for team until the payload is being created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `one-app` will be documented in this file.
 
+## v1.0.20 - 2024-06-04
+
+### What's Changed
+
+* Bump dependabot/fetch-metadata from 1.6.0 to 2.0.0 by @dependabot in https://github.com/envor/one-app/pull/22
+* Bump aglipanci/laravel-pint-action from 2.3.1 to 2.4 by @dependabot in https://github.com/envor/one-app/pull/23
+* Bump dependabot/fetch-metadata from 2.0.0 to 2.1.0 by @dependabot in https://github.com/envor/one-app/pull/24
+* strings for optional uuid types by @inmanturbo in https://github.com/envor/one-app/pull/25
+
+**Full Changelog**: https://github.com/envor/one-app/compare/v1.0.19...v1.0.20
+
 ## v1.0.19 - 2024-03-22
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ laravel new one-app
 ### Or using composer
 
 ```bash
-composer create project "laravel/laravel:^11.0" one-app
+composer create-project "laravel/laravel:^11.0" one-app
 ```
 
 ```bash

--- a/stubs/one-app/app/Providers/DomainServiceProvider.php
+++ b/stubs/one-app/app/Providers/DomainServiceProvider.php
@@ -55,20 +55,16 @@ class DomainServiceProvider extends ServiceProvider
 
     public function configureQueue()
     {
-        if (isset($this->app['team'])) {
-            $this->app['queue']->createPayloadUsing(function () {
-                return $this->app['team'] ? [
-                    'team_uuid' => $this->app['team']->uuid,
-                ] : [];
-            });
-        }
+        $this->app['queue']->createPayloadUsing(function () {
+            return isset($this->app['team']) ? [
+                'team_uuid' => $this->app['team']->uuid,
+            ] : [];
+        });
 
         $this->app['events']->listen(JobProcessing::class, function ($event) {
-            if (isset($event->job->payload['team_uuid'])) {
-                $team = Team::whereUuid($event->job->payload['team_uuid'])->first();
-                if (isset($team->id)) {
-                    $team->configure()->use();
-                }
+            if (isset($event->job->payload()['team_uuid'])) {
+                $team = Team::where('uuid', $event->job->payload()['team_uuid'])->first();
+                $team->configure()->use();
             }
         });
     }

--- a/stubs/one-app/app/Providers/DomainServiceProvider.php
+++ b/stubs/one-app/app/Providers/DomainServiceProvider.php
@@ -43,8 +43,7 @@ class DomainServiceProvider extends ServiceProvider
 
                 // migrate only once a day
                 if (! cache()->has('team_migrated_'.$team->id)) {
-                    $team
-                        ->migrate();
+                    $team->migrate();
                     cache()->put('team_migrated_'.$team->id, true, now()->addDay());
                 }
 


### PR DESCRIPTION
When the application boots there is not team yet -- it is typically set by middleware unless the team has a registered domain.